### PR TITLE
Fix InfiniteArrows duplication glitches

### DIFF
--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_InfiniteArrows.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_InfiniteArrows.java
@@ -3,16 +3,15 @@ package me.ryanhamshire.GPFlags.flags;
 import me.ryanhamshire.GPFlags.*;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
-import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.AbstractArrow;
+import org.bukkit.entity.Arrow;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.projectiles.ProjectileSource;
 
 import java.util.Arrays;
@@ -24,23 +23,28 @@ public class FlagDef_InfiniteArrows extends FlagDefinition {
     public void onProjectileHit(ProjectileHitEvent event) {
         if (event.getEntityType() != EntityType.ARROW && event.getEntityType() != EntityType.SNOWBALL) return;
 
-        Projectile arrow = event.getEntity();
-
-        ProjectileSource source = arrow.getShooter();
-        if (source == null || !(source instanceof Player)) return;
+        ProjectileSource source = event.getEntity().getShooter();
+        if (!(source instanceof Player)) return;
 
         Player player = (Player) source;
         if (player.getGameMode() == GameMode.CREATIVE) return;
 
-        Flag flag = this.GetFlagInstanceAtLocation(arrow.getLocation(), player);
+        Flag flag = this.GetFlagInstanceAtLocation(event.getEntity().getLocation(), player);
         if (flag == null) return;
 
         PlayerInventory inventory = player.getInventory();
-        ItemMeta meta = inventory.getItemInMainHand().getItemMeta();
-        if (meta != null && meta.hasEnchant(Enchantment.ARROW_INFINITE)) return;
+
+        if (event.getEntityType() == EntityType.SNOWBALL) {
+            inventory.addItem(new ItemStack(Material.SNOWBALL));
+            return;
+        }
+
+        Arrow arrow = (Arrow) event.getEntity();
+        if (arrow.getPickupStatus() != AbstractArrow.PickupStatus.ALLOWED) return;
 
         arrow.remove();
         inventory.addItem(new ItemStack(Material.ARROW));
+
     }
 
     public FlagDef_InfiniteArrows(FlagManager manager, GPFlags plugin) {


### PR DESCRIPTION
Before this fix players were able to convert thrown snowballs into arrows, use a crossbow with multishot enchant to duplicate arrows, use NoPlayerDamage+InfiniteArrows flags to duplicate arrows after rapid self-shots, and possibly use a crossbow with piercing enchant to duplicate arrows.