### PR TITLE
Fix Snowball -> Arrow exploit

### DIFF
--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_InfiniteArrows.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_InfiniteArrows.java
@@ -22,7 +22,7 @@ public class FlagDef_InfiniteArrows extends FlagDefinition {
 
     @EventHandler(priority = EventPriority.LOW)
     public void onProjectileHit(ProjectileHitEvent event) {
-        if (event.getEntityType() != EntityType.ARROW && event.getEntityType() != EntityType.SNOWBALL) return;
+        if (event.getEntityType() != EntityType.ARROW) return;
 
         Projectile arrow = event.getEntity();
 


### PR DESCRIPTION
When a player throws a snowball in a claim with the InfiniteArrows flag, they are given an arrow. I assume this is not intended behavior. With this change, the flag will ignore any snowballs that are thrown. I tested this on my server and it seemed to have worked!