### PR TITLE
Fix exception with ProtectNamedMobs

### DIFF
--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_ProtectNamedMobs.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_ProtectNamedMobs.java
@@ -36,6 +36,7 @@ public class FlagDef_ProtectNamedMobs extends FlagDefinition {
         Entity damager = event.getDamager();
         if (damager.getType() != EntityType.PLAYER) {
             event.setCancelled(true);
+            return;
         }
 
         Player player = (Player) damager;


### PR DESCRIPTION
If a non-player attacked an entity in a claim, it would try to cast the damager into a player