### PR TITLE
Revamp novehicle claimflag

### DIFF
--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
@@ -36,6 +36,8 @@ public class FlagDef_NoVehicle extends FlagDefinition {
     @EventHandler
     private void onVehicleMove(VehicleMoveEvent event) {
         Vehicle vehicle = event.getVehicle();
+        List<Entity> passengers = vehicle.getPassengers();
+        if (passengers.size() == 0) return;
         Entity passenger = vehicle.getPassengers().get(0);
         if (passenger == null) return;
         if (!(passenger instanceof Player)) return;

--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
@@ -38,7 +38,7 @@ public class FlagDef_NoVehicle extends FlagDefinition {
         Vehicle vehicle = event.getVehicle();
         List<Entity> passengers = vehicle.getPassengers();
         if (passengers.size() == 0) return;
-        Entity passenger = vehicle.getPassengers().get(0);
+        Entity passenger = passengers.get(0);
         if (!(passenger instanceof Player)) return;
         Player player = (Player) passenger;
         handleVehicleMovement(player, vehicle, event.getFrom(), event.getTo(), false);

--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
@@ -39,10 +39,9 @@ public class FlagDef_NoVehicle extends FlagDefinition {
         List<Entity> passengers = vehicle.getPassengers();
         if (passengers.size() == 0) return;
         Entity passenger = vehicle.getPassengers().get(0);
-        if (passenger == null) return;
         if (!(passenger instanceof Player)) return;
         Player player = (Player) passenger;
-        handleVehicleMovement(player, vehicle, event.getFrom(), event.getTo(), event.getEventName());
+        handleVehicleMovement(player, vehicle, event.getFrom(), event.getTo(), false);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -50,17 +49,17 @@ public class FlagDef_NoVehicle extends FlagDefinition {
         Player player = event.getPlayer();
         Entity vehicle = player.getVehicle();
         if (vehicle instanceof Vehicle) {
-            handleVehicleMovement(player, (Vehicle) vehicle, event.getFrom(), event.getTo(), event.getEventName());
+            handleVehicleMovement(player, (Vehicle) vehicle, event.getFrom(), event.getTo(), true);
         }
     }
 
-    private void handleVehicleMovement(Player player, Vehicle vehicle, Location locFrom, Location locTo, String eventName) {
+    private void handleVehicleMovement(Player player, Vehicle vehicle, Location locFrom, Location locTo, boolean isTeleportEvent) {
         Flag flag = this.getFlagInstanceAtLocation(locTo, player);
         if (flag != null) {
             Claim claim = GriefPrevention.instance.dataStore.getClaimAt(locTo, false, null);
             if (claim.getOwnerName().equals(player.getName())) return;
             if (claim.hasExplicitPermission(player, ClaimPermission.Inventory)) return;
-            if (eventName.equals("PlayerTeleportEvent")) {
+            if (isTeleportEvent) {
                 player.leaveVehicle();
                 GPFlags.sendMessage(player, TextMode.Err, Messages.NoVehicleAllowed);
                 return;

--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
@@ -96,8 +96,17 @@ public class FlagDef_NoVehicle extends FlagDefinition {
 
     @EventHandler
     private void onCollision(VehicleEntityCollisionEvent event) {
-        Flag flag = this.getFlagInstanceAtLocation(event.getVehicle().getLocation(), null);
+        Vehicle vehicle = event.getVehicle();
+        Flag flag = this.getFlagInstanceAtLocation(vehicle.getLocation(), null);
         if (flag != null) {
+            Entity entity = event.getEntity();
+            if (entity instanceof Player) {
+                Player player = (Player) entity;
+                Claim claim = GriefPrevention.instance.dataStore.getClaimAt(vehicle.getLocation(), false, null);
+                if (claim == null) return;
+                if (claim.getOwnerName().equals(player.getName())) return;
+                if (claim.hasExplicitPermission(player, ClaimPermission.Inventory)) return;
+            }
             event.setCollisionCancelled(true);
             event.setCancelled(true);
         }

--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
@@ -36,10 +36,10 @@ public class FlagDef_NoVehicle extends FlagDefinition {
     @EventHandler
     private void onVehicleMove(VehicleMoveEvent event) {
         Vehicle vehicle = event.getVehicle();
-        Player player;
         Entity passenger = vehicle.getPassengers().get(0);
+        if (passenger == null) return;
         if (!(passenger instanceof Player)) return;
-        player = (Player) passenger;
+        Player player = (Player) passenger;
         handleVehicleMovement(player, vehicle, event.getFrom(), event.getTo(), event.getEventName());
     }
 
@@ -60,6 +60,7 @@ public class FlagDef_NoVehicle extends FlagDefinition {
             if (claim.hasExplicitPermission(player, ClaimPermission.Inventory)) return;
             if (eventName.equals("PlayerTeleportEvent")) {
                 player.leaveVehicle();
+                GPFlags.sendMessage(player, TextMode.Err, Messages.NoVehicleAllowed);
                 return;
             }
             vehicle.eject();

--- a/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/flags/FlagDef_NoVehicle.java
@@ -17,14 +17,12 @@ import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.block.Action;
-import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
+import org.bukkit.event.vehicle.VehicleEntityCollisionEvent;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
-import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
 
 import java.util.Collections;
 import java.util.List;
@@ -38,54 +36,41 @@ public class FlagDef_NoVehicle extends FlagDefinition {
     @EventHandler
     private void onVehicleMove(VehicleMoveEvent event) {
         Vehicle vehicle = event.getVehicle();
-        for (Entity entity : vehicle.getPassengers()) {
-            if (entity instanceof Player) {
-                Player player = ((Player) entity);
-                handleVehicleMovement(player, vehicle, event.getFrom(), event.getTo());
-            }
-        }
+        Player player;
+        Entity passenger = vehicle.getPassengers().get(0);
+        if (!(passenger instanceof Player)) return;
+        player = (Player) passenger;
+        handleVehicleMovement(player, vehicle, event.getFrom(), event.getTo(), event.getEventName());
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST)
     private void onTeleport(PlayerTeleportEvent event) {
         Player player = event.getPlayer();
         Entity vehicle = player.getVehicle();
         if (vehicle instanceof Vehicle) {
-            handleVehicleMovement(player, ((Vehicle) vehicle), event.getFrom(), event.getTo());
+            handleVehicleMovement(player, (Vehicle) vehicle, event.getFrom(), event.getTo(), event.getEventName());
         }
     }
 
-    private void handleVehicleMovement(Player player, Vehicle vehicle, Location locFrom, Location locTo) {
+    private void handleVehicleMovement(Player player, Vehicle vehicle, Location locFrom, Location locTo, String eventName) {
         Flag flag = this.getFlagInstanceAtLocation(locTo, player);
         if (flag != null) {
             Claim claim = GriefPrevention.instance.dataStore.getClaimAt(locTo, false, null);
-            if (!claim.hasExplicitPermission(player, ClaimPermission.Inventory)) {
-                vehicle.eject();
-                ItemStack itemStack = Util.getItemFromVehicle(vehicle);
-                if (itemStack != null) {
-                    vehicle.getWorld().dropItem(locFrom, itemStack);
-                }
-                vehicle.remove();
-                GPFlags.sendMessage(player, TextMode.Err, Messages.NoVehicleAllowed);
+            if (claim.getOwnerName().equals(player.getName())) return;
+            if (claim.hasExplicitPermission(player, ClaimPermission.Inventory)) return;
+            if (eventName.equals("PlayerTeleportEvent")) {
+                player.leaveVehicle();
+                return;
             }
-        }
-    }
-
-    @EventHandler
-    private void onPlaceVehicle(PlayerInteractEvent event) {
-        Player player = event.getPlayer();
-        PlayerInventory inventory = player.getInventory();
-        EquipmentSlot hand = event.getHand();
-        Action action = event.getAction();
-
-        if (action != Action.RIGHT_CLICK_BLOCK && action != Action.RIGHT_CLICK_AIR) return;
-
-        if ((Util.isAVehicle(inventory.getItemInMainHand()) && hand == EquipmentSlot.HAND) ||
-                (Util.isAVehicle(inventory.getItemInOffHand()) && hand == EquipmentSlot.OFF_HAND)) {
-            Flag flag = this.getFlagInstanceAtLocation(player.getLocation(), player);
-            if (flag == null) return;
-            event.setCancelled(true);
-            GPFlags.sendMessage(player, TextMode.Err, Messages.NoPlaceVehicle);
+            vehicle.eject();
+            ItemStack itemStack = Util.getItemFromVehicle(vehicle);
+            if (itemStack != null) {
+                if (vehicle.isValid()) {
+                    vehicle.getWorld().dropItem(locFrom, itemStack);
+                    vehicle.remove();
+                }
+            }
+            GPFlags.sendMessage(player, TextMode.Err, Messages.NoVehicleAllowed);
         }
     }
 
@@ -99,11 +84,20 @@ public class FlagDef_NoVehicle extends FlagDefinition {
             Flag flag = this.getFlagInstanceAtLocation(vehicle.getLocation(), player);
             if (flag != null) {
                 Claim claim = GriefPrevention.instance.dataStore.getClaimAt(vehicle.getLocation(), false, null);
-                if (claim != null && !claim.hasExplicitPermission(player, ClaimPermission.Inventory)) {
+                if (claim != null && !claim.hasExplicitPermission(player, ClaimPermission.Inventory) && !claim.getOwnerName().equals(player.getName())) {
                     event.setCancelled(true);
                     GPFlags.sendMessage(player, TextMode.Err, Messages.NoEnterVehicle);
                 }
             }
+        }
+    }
+
+    @EventHandler
+    private void onCollision(VehicleEntityCollisionEvent event) {
+        Flag flag = this.getFlagInstanceAtLocation(event.getVehicle().getLocation(), null);
+        if (flag != null) {
+            event.setCollisionCancelled(true);
+            event.setCancelled(true);
         }
     }
 


### PR DESCRIPTION
1: Fixes an exploit where if two players who do not have permission in a claim ride a boat into a claim with novehicle, they can duplicate the boat. Both of them would have the boat in their inventory.
2. Since griefprevention already disables placement of vehicles in a claim for players without permission, I have removed that part of the code
3. Instead of breaking the vehicle on teleport into a novehicle claim, this will just remove the player from the vehicle, and then teleport just the player.
4. The claim owner used to not have permission to ride a boat in their own novehicle claim. This grants them that ability. Same for mounting.
5. If the player driving the boat has permission in the claim, allow them to continue riding it even if the second passenger doesn't.
6. Prevents all pushing of vehicles inside of novehicle claims.

This has been tested on my own server for several minutes without any issues.

I think a possible disadvantage for these changes is just that the way that the novehicle flag works has been completely revamped since the original 5.9.3. The one part of it that was working (preventing vehicle placement) was removed and a whole bunch of new stuff was added. Perhaps, it might make more sense to revert the novehicle flag to what it used to be in the original 5.9.3 and make a new claimflag for all of these changes.