### PR TITLE
Fly and NoEnter improvements

### DIFF
--- a/src/main/java/me/ryanhamshire/GPFlags/CommandHandler.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/CommandHandler.java
@@ -528,7 +528,9 @@ public class CommandHandler {
                 World world = player.getWorld();
                 for (Player p: world.getPlayers()) {
                     if (claim.contains(p.getLocation(), true, false)) {
-                        p.setAllowFlight(true);
+                        if (claim.getPermission(p.getUniqueId().toString()) == ClaimPermission.Access) {
+                            p.setAllowFlight(true);
+                        }
                     }
                 }
             }

--- a/src/main/java/me/ryanhamshire/GPFlags/CommandHandler.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/CommandHandler.java
@@ -9,6 +9,7 @@ import me.ryanhamshire.GriefPrevention.PlayerData;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -497,6 +498,40 @@ public class CommandHandler {
             ChatColor color = result.success ? TextMode.Success : TextMode.Err;
             GPFlags.sendMessage(player, color, result.message.messageID, result.message.messageParams);
             if (result.success) plugin.getFlagManager().save();
+
+            if (args[0].equalsIgnoreCase("NoEnter") && args.length >= 2) {
+                World world = player.getWorld();
+                for (Player p: world.getPlayers()) {
+                    if (claim.contains(p.getLocation(), true, false)) {
+                        if (claim.getPermission(p.getName()) == null && !claim.getOwnerName().equals(p.getName())) {
+                            GriefPrevention.instance.ejectPlayer(p);
+                        }
+                    }
+                }
+            }
+            if (args[0].equalsIgnoreCase("NoEnterPlayer") && args.length >= 2) {
+                for (int i = 1; i < args.length; i++) {
+                    Player target = Bukkit.getPlayer(args[i]);
+                    if (target != null && target.getName().equals(args[i])) {
+                        if (claim.contains(target.getLocation(), true, false)) {
+                            if (claim.getPermission(args[i]) == null) {
+                                GriefPrevention.instance.ejectPlayer(target);
+                            }
+                        }
+                    }
+                }
+            }
+            if (args[0].equalsIgnoreCase("OwnerFly")) {
+                player.setAllowFlight(true);
+            }
+            if (args[0].equalsIgnoreCase("OwnerMemberFly")) {
+                World world = player.getWorld();
+                for (Player p: world.getPlayers()) {
+                    if (claim.contains(p.getLocation(), true, false)) {
+                        p.setAllowFlight(true);
+                    }
+                }
+            }
 
             return true;
         } else if (cmd.getName().equalsIgnoreCase("UnSetClaimFlag") && player != null) {

--- a/src/main/java/me/ryanhamshire/GPFlags/CommandHandler.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/CommandHandler.java
@@ -525,6 +525,7 @@ public class CommandHandler {
                 player.setAllowFlight(true);
             }
             if (args[0].equalsIgnoreCase("OwnerMemberFly")) {
+                player.setAllowFlight(true);
                 World world = player.getWorld();
                 for (Player p: world.getPlayers()) {
                     if (claim.contains(p.getLocation(), true, false)) {

--- a/src/main/java/me/ryanhamshire/GPFlags/CommandHandler.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/CommandHandler.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import me.ryanhamshire.GPFlags.flags.FlagDef_ChangeBiome;
 import me.ryanhamshire.GPFlags.flags.FlagDefinition;
 import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.ClaimPermission;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
 import me.ryanhamshire.GriefPrevention.PlayerData;
 import org.apache.commons.lang.Validate;


### PR DESCRIPTION
Before the changes: Using the ownerfly/ownermemberfly claimflag would require players to leave and re-enter the claim before it would let you fly. Similarly, the noenter/noenterplayer would allow the claimbanned player(s) to stay in the claim until they left the claim on their own. 

After the changes: Fly is activated immediately for players without needing them to leave and re-enter the claim. Additionally, noenter/noenterplayer kicks the target player(s) out of the claim. 

I know that the structure of my code could be better - I just wasn't sure how to go about it the 'right' way. I lightly tested the code on my test server before making this PR and just recently added it to my production server.