### PR TITLE
Fix exception with nomobspawnstype

### DIFF
--- a/src/main/java/me/ryanhamshire/GPFlags/CommandHandler.java
+++ b/src/main/java/me/ryanhamshire/GPFlags/CommandHandler.java
@@ -484,6 +484,7 @@ public class CommandHandler {
             // Permissions for mob type
             if (flagName.equalsIgnoreCase("NoMobSpawnsType")) {
                 if (!player.hasPermission("gpflags.nomobspawnstype.*") && !player.hasPermission("gpflags.admin.*")) {
+                    if (params == null) return false;
                     for (String type : params[0].split(";")) {
                         if (!player.hasPermission("gpflags.nomobspawnstype." + type)) {
                             GPFlags.sendMessage(player, TextMode.Err, Messages.MobTypePerm, type);


### PR DESCRIPTION
When you did /setclaimflag nomobspawnstype without specifying the type, it would throw an error. This fixes that. 
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
Untested.